### PR TITLE
Cleanup composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,10 @@
         }
     ],
     "require": {
-        "laravel/framework": "^6.0|^7.0|^8.0",
+        "php": "^7.1",
+        "ext-json": "*",
+        "illuminate/http": "^6.0|^7.0|^8.0",
+        "illuminate/support": "^6.0|^7.0|^8.0",
         "rennokki/laravel-sns-events": "^6.0"
     },
     "autoload": {
@@ -35,6 +38,7 @@
         "sort-packages": true
     },
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "extra": {
         "laravel": {
             "providers": [


### PR DESCRIPTION
- Require php >= 7.1
- Require ext-json
  *Above changes are based on (static) code analysis using PhpStorm*

- Use Illuminate packages instead of laravel/framework
  *This allows the package to be used outside of a full laravel install*

- Add "prefer-stable"
  *This ensures that by default only stable packages are installed during development (unless explicitly requested otherwise) to reduce the chance that unreleased features are used*