### PR TITLE
Move `GeneratesSnsMessages` trait to public

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,45 @@ class MyEventbridgeController extends EventbridgeWebhook
 }
 ```
 
+## Testing SES Controllers
+
+The package comes with a `GeneratesSnsMessages`-trait to create a valid SES payload to be used for your tests.
+Use the trait like in the example below to get started writing tests for your own controllers.
+
+```php
+use RenokiCo\AwsWebhooks\Concerns\GeneratesSnsMessages;
+
+class MySesControllerTest extends TestCase
+{
+    use GeneratesSnsMessages;
+
+    public static function setUpBeforeClass(): void
+    {
+        static::initializeSsl();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        static::tearDownSsl();
+    }
+
+    public function getSesMessage(string $type): array
+    {
+        return $this->getNotificationPayload([
+            'eventType' => $type,
+        ]);
+    }
+
+    public function test_my_ses_controller()
+    {
+        $payload = $this->getSesMessage('Bounce');
+
+        $response = $this->withHeaders($this->getHeadersForMessage($payload))
+            ->json('GET', route('ses', ['certificate' => static::$certificate]), $payload);
+    }
+}
+```
+
 ## 🐛 Testing
 
 ``` bash

--- a/src/Concerns/GeneratesSnsMessages.php
+++ b/src/Concerns/GeneratesSnsMessages.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RenokiCo\AwsWebhooks\Test\Concerns;
+namespace RenokiCo\AwsWebhooks\Concerns;
 
 use Aws\Sns\Message;
 use Aws\Sns\MessageValidator;

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,10 +3,11 @@
 namespace RenokiCo\AwsWebhooks\Test;
 
 use Orchestra\Testbench\TestCase as Orchestra;
+use RenokiCo\AwsWebhooks\Concerns\GeneratesSnsMessages;
 
 abstract class TestCase extends Orchestra
 {
-    use \RenokiCo\AwsWebhooks\Concerns\GeneratesSnsMessages;
+    use GeneratesSnsMessages;
 
     /**
      * {@inheritdoc}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,7 +6,7 @@ use Orchestra\Testbench\TestCase as Orchestra;
 
 abstract class TestCase extends Orchestra
 {
-    use Concerns\GeneratesSnsMessages;
+    use \RenokiCo\AwsWebhooks\Concerns\GeneratesSnsMessages;
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
As discussed in #12, this PR moves the `GeneratesSnsMessages` trait to `/src` to make it consumable.

Just saw that [renoki-co/laravel-sns-events](https://github.com/renoki-co/laravel-sns-events/blob/master/tests/Concerns/GeneratesSnsMessages.php) has the same trait. 