### PR TITLE
[fix] Add check for eventType or notificationType in AWS SES handler

### DIFF
--- a/src/Http/Controllers/SesWebhook.php
+++ b/src/Http/Controllers/SesWebhook.php
@@ -19,8 +19,7 @@ class SesWebhook extends SnsController
     {
         $decodedMessage = json_decode($snsMessage['Message'], true);
 
-        $typeKey = (array_key_exists("eventType", $decodedMessage) ? "eventType" : "notificationType");
-
+        $typeKey = array_key_exists('eventType', $decodedMessage) ? 'eventType' : 'notificationType';
         $eventType = $decodedMessage[$typeKey] ?? null;
 
         $methodToCall = 'on'.Str::studly($eventType);


### PR DESCRIPTION
Hi,

I tried to use this package and during testing I saw that AWS sends notifications but I had problems with registering response in application. I was testing with AWS bounce@simulator.amazonses.com and  complaint@simulator.amazonses.com addresses.

After some debugging I figured out that problem is in response. This package check for $decodedMessage['eventType'] but in my response from AWS there is no eventType key, but instead I had notificationType.

Response is basically same only difference is in object key name ( eventType -> notificationType ).

I fixed this in my project by overriding onNotification method and adding check for type and everything else works as expected.

Here you can read more about this issue - https://github.com/mautic/mautic/issues/8903#issuecomment-698275908  